### PR TITLE
Refactor document initialize

### DIFF
--- a/lib/similarity/document.rb
+++ b/lib/similarity/document.rb
@@ -1,22 +1,17 @@
 class Document
   attr_reader :content, :id
 
-  def initialize(hash_args)
-    content = hash_args[:content]
+  def initialize(content, id = nil)
     if content && !content.empty?
       @content = content
-      @term_frequency = nil
-      @terms = nil
     else
       raise ArgumentError, "text cannot be nil or blank"
     end
 
-    id = hash_args[:id]
-    if id && !id.nil?
-      @id = id
-    else
-      @id = self.object_id
-    end
+    @term_frequency = nil
+    @terms = nil
+
+    @id = id ? id : self.object_id
   end
 
   def terms

--- a/test/test_corpus.rb
+++ b/test/test_corpus.rb
@@ -3,8 +3,8 @@ require 'helper'
 class TestCorpus < Test::Unit::TestCase
   def test_adding_documents_increments_document_count
     corpus = Corpus.new
-    doc1 = Document.new(:content => "cow cow cow")
-    doc2 = Document.new(:content => "horse horse horse")
+    doc1 = Document.new("cow cow cow")
+    doc2 = Document.new("horse horse horse")
 
     corpus << doc1
     corpus << doc2
@@ -14,8 +14,8 @@ class TestCorpus < Test::Unit::TestCase
 
   def test_adding_documents_adds_terms
     corpus = Corpus.new
-    doc1 = Document.new(:content => "cow cow cow bird")
-    doc2 = Document.new(:content => "horse horse horse bird")
+    doc1 = Document.new("cow cow cow bird")
+    doc2 = Document.new("horse horse horse bird")
 
     corpus << doc1
     corpus << doc2
@@ -34,8 +34,8 @@ class TestCorpus < Test::Unit::TestCase
 
   def test_inverse_document_frequency
     corpus = Corpus.new
-    doc1 = Document.new(:content => "cow cow cow")
-    doc2 = Document.new(:content => "horse horse horse")
+    doc1 = Document.new("cow cow cow")
+    doc2 = Document.new("horse horse horse")
 
     corpus << doc1
     corpus << doc2
@@ -49,9 +49,9 @@ class TestCorpus < Test::Unit::TestCase
 
   def test_similar_documents
     corpus = Corpus.new
-    doc1 = Document.new(:content => "bird bird bird")
-    doc2 = Document.new(:content => "pig pig pig bird")
-    doc3 = Document.new(:content => "horse horse bird bird")
+    doc1 = Document.new("bird bird bird")
+    doc2 = Document.new("pig pig pig bird")
+    doc3 = Document.new("horse horse bird bird")
 
     corpus << doc1
     corpus << doc2
@@ -68,8 +68,8 @@ class TestCorpus < Test::Unit::TestCase
 
   def test_weights
     corpus = Corpus.new
-    doc1 = Document.new(:content => "cow horse sheep")
-    doc2 = Document.new(:content => "horse bird dog")
+    doc1 = Document.new("cow horse sheep")
+    doc2 = Document.new("horse bird dog")
 
     corpus << doc1
     corpus << doc2
@@ -79,9 +79,9 @@ class TestCorpus < Test::Unit::TestCase
 
   def test_weights_sorts
     corpus = Corpus.new
-    doc1 = Document.new(:content => "Returns a string containing a representation")
-    corpus << Document.new(:content => "Adds a string containing a representation")
-    corpus << Document.new(:content => "Representation of a string")
+    doc1 = Document.new("Returns a string containing a representation")
+    corpus << Document.new("Adds a string containing a representation")
+    corpus << Document.new("Representation of a string")
 
     corpus << doc1
 
@@ -91,8 +91,8 @@ class TestCorpus < Test::Unit::TestCase
 
   def test_term_frequency_matrix
     corpus = Corpus.new
-    corpus << Document.new(:content => "cow horse sheep")
-    corpus << Document.new(:content => "horse bird dog")
+    corpus << Document.new("cow horse sheep")
+    corpus << Document.new("horse bird dog")
 
     tdm = corpus.term_document_matrix
     assert tdm.instance_of? TermDocumentMatrix
@@ -100,8 +100,8 @@ class TestCorpus < Test::Unit::TestCase
 
   def test_remove_infrequent_terms
     corpus = Corpus.new
-    corpus << Document.new(:content => "cow horse sheep")
-    corpus << Document.new(:content => "horse bird dog")
+    corpus << Document.new("cow horse sheep")
+    corpus << Document.new("horse bird dog")
 
     assert_equal 5, corpus.terms.size
 
@@ -114,8 +114,8 @@ class TestCorpus < Test::Unit::TestCase
 
   def test_remove_frequent_terms
     corpus = Corpus.new
-    corpus << Document.new(:content => "cow horse sheep")
-    corpus << Document.new(:content => "horse bird dog")
+    corpus << Document.new("cow horse sheep")
+    corpus << Document.new("horse bird dog")
 
     assert_equal 5, corpus.terms.size
 

--- a/test/test_document.rb
+++ b/test/test_document.rb
@@ -2,52 +2,52 @@ require 'helper'
 
 class TestDocument < Test::Unit::TestCase
   def test_initialize
-    document = Document.new(:content => "The quick brown fox")
+    document = Document.new("The quick brown fox")
     assert_equal document.content, "The quick brown fox"
   end
 
   def test_initialize_with_id
-    document = Document.new(:content => "The quick brown fox", :id => "new")
+    document = Document.new("The quick brown fox", "new")
     assert_equal document.content, "The quick brown fox"
     assert_equal document.id, "new"
   end
 
   def test_initialize_with_no_id
-    document = Document.new(:content => "The quick brown fox")
+    document = Document.new("The quick brown fox")
     assert_equal document.content, "The quick brown fox"
     assert_equal document.id, document.object_id
   end
 
   def test_initialize_with_nil
-    assert_raise(ArgumentError) { Document.new(:content => nil) }
+    assert_raise(ArgumentError) { Document.new(nil) }
   end
 
   def test_initialize_with_blank
-    assert_raise(ArgumentError) { Document.new(:content => "") }
+    assert_raise(ArgumentError) { Document.new("") }
   end
 
   def test_term_extraction
-    document = Document.new(:content => "the quick brown fox")
+    document = Document.new("the quick brown fox")
     assert_equal document.terms, ["the", "quick", "brown", "fox"]
   end
 
   def test_term_extraction_removes_spaces
-    document = Document.new(:content => "the quick     brown   fox")
+    document = Document.new("the quick     brown   fox")
     assert_equal document.terms, ["the", "quick", "brown", "fox"]
   end
 
   def test_term_extraction_downcases
-    document = Document.new(:content => "The Quick Brown Fox")
+    document = Document.new("The Quick Brown Fox")
     assert_equal document.terms, ["the", "quick", "brown", "fox"]
   end
 
   def test_term_extraction_removes_punctuation
-    document = Document.new(:content => 'The, Quick! Brown. "Fox"')
+    document = Document.new('The, Quick! Brown. "Fox"')
     assert_equal document.terms, ["the", "quick", "brown", "fox"]
   end
 
   def test_term_frequencies
-    document = Document.new(:content => 'cow cow cow horse horse elephant')
+    document = Document.new('cow cow cow horse horse elephant')
     assert document.term_frequencies.is_a? Hash
 
     # should have 3 terms
@@ -61,7 +61,7 @@ class TestDocument < Test::Unit::TestCase
   end
 
   def test_term_frequency
-    document = Document.new(:content => 'cow cow cow horse horse elephant')
+    document = Document.new('cow cow cow horse horse elephant')
 
     # frequency of cow should be 3/6 = 0.5
     assert_equal document.term_frequency('cow'), 0.5
@@ -71,7 +71,7 @@ class TestDocument < Test::Unit::TestCase
   end
 
   def test_has_term
-    document = Document.new(:content => 'cow cow cow horse horse elephant')
+    document = Document.new('cow cow cow horse horse elephant')
 
     assert_equal true, document.has_term?('cow')
     assert_equal false, document.has_term?('sheep')

--- a/test/test_term_document_matrix.rb
+++ b/test/test_term_document_matrix.rb
@@ -4,8 +4,8 @@ class TestTermDocumentMatrix < Test::Unit::TestCase
   # using worked example from log book, this should return a similarity of 1
   def test_similarity_matrix
     corpus = Corpus.new
-    doc1 = Document.new(:content => "cow horse sheep")
-    doc2 = Document.new(:content => "horse bird dog")
+    doc1 = Document.new("cow horse sheep")
+    doc2 = Document.new("horse bird dog")
 
     corpus << doc1
     corpus << doc2
@@ -19,8 +19,8 @@ class TestTermDocumentMatrix < Test::Unit::TestCase
 
   def test_number_of_terms
     corpus = Corpus.new
-    corpus << Document.new(:content => "cow horse sheep")
-    corpus << Document.new(:content => "horse bird dog")
+    corpus << Document.new("cow horse sheep")
+    corpus << Document.new("horse bird dog")
 
     tdm = TermDocumentMatrix.new(corpus)
 
@@ -29,8 +29,8 @@ class TestTermDocumentMatrix < Test::Unit::TestCase
 
   def test_number_of_documents
     corpus = Corpus.new
-    corpus << Document.new(:content => "cow horse sheep")
-    corpus << Document.new(:content => "horse bird dog")
+    corpus << Document.new("cow horse sheep")
+    corpus << Document.new("horse bird dog")
 
     tdm = TermDocumentMatrix.new(corpus)
 
@@ -39,8 +39,8 @@ class TestTermDocumentMatrix < Test::Unit::TestCase
 
   def test_non_zeros
     corpus = Corpus.new
-    corpus << Document.new(:content => "cow horse sheep")
-    corpus << Document.new(:content => "horse bird dog")
+    corpus << Document.new("cow horse sheep")
+    corpus << Document.new("horse bird dog")
 
     tdm = TermDocumentMatrix.new(corpus)
     assert_equal 2, tdm.non_zeros


### PR DESCRIPTION
Use separate arguments instead of hash to reduce verbosity.

This causes great changes to the API of the `Document` class, therefore, if merged, you should bump your major version according to http://semver.org/
